### PR TITLE
Implement Daily GitHub Summary Report Workflow

### DIFF
--- a/.github/workflows/daily_summary_report.yml
+++ b/.github/workflows/daily_summary_report.yml
@@ -50,3 +50,33 @@ jobs:
           echo "**Open Issues:** ${{ steps.fetch_repository_data.outputs.openIssues }}" >> report.md
           echo "**Closed Issues:** ${{ steps.fetch_repository_data.outputs.closedIssues }}" >> report.md
         # Add the actual steps for generating and distributing the report as needed
+   save_report:
+     needs: generate-report
+     runs-on: ubuntu-latest
+     steps:
+       - name: Checkout repository
+         uses: actions/checkout@v2
+       - name: Save report to 'daily_summary.md'
+         run: |
+           mv report.md daily_summary.md
+       - name: Commit and push report
+         uses: actions/github-script@v5
+         with:
+           script: |
+             const fs = require('fs');
+             const path = './daily_summary.md';
+             const github = require('@actions/github');
+             const core = require('@actions/core');
+             const exec = require('@actions/exec');
+             async function run() {
+               const message = 'chore: Update daily summary report';
+               const email = 'github-actions[bot]@users.noreply.github.com';
+               const name = 'github-actions[bot]';
+               const branch = 'main';
+               await exec.exec('git', ['config', '--local', 'user.email', email]);
+               await exec.exec('git', ['config', '--local', 'user.name', name]);
+               await exec.exec('git', ['add', path]);
+               await exec.exec('git', ['commit', '-m', message, '--allow-empty']);
+               await exec.exec('git', ['push']);
+             }
+             run();

--- a/.github/workflows/daily_summary_report.yml
+++ b/.github/workflows/daily_summary_report.yml
@@ -35,5 +35,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Generate report
-        run: echo 'Report generation script goes here.'
+        run: |
+          echo "## Daily Summary Report" > report.md
+          echo "**Date:** $(date '+%Y-%m-%d')" >> report.md
+          echo "**Number of Commits:** ${{ steps.fetch_repository_data.outputs.commitMessages | length }}" >> report.md
+          echo "**Commit Messages:**" >> report.md
+          for msg in ${{ join(fromJson(steps.fetch_repository_data.outputs.commitMessages), '\\n') }}; do
+            echo "- $msg" >> report.md
+          done
+          echo "**Authors:**" >> report.md
+          for author in ${{ join(fromJson(steps.fetch_repository_data.outputs.commitAuthors), '\\n') }}; do
+            echo "- $author" >> report.md
+          done
+          echo "**Open Issues:** ${{ steps.fetch_repository_data.outputs.openIssues }}" >> report.md
+          echo "**Closed Issues:** ${{ steps.fetch_repository_data.outputs.closedIssues }}" >> report.md
         # Add the actual steps for generating and distributing the report as needed

--- a/.github/workflows/daily_summary_report.yml
+++ b/.github/workflows/daily_summary_report.yml
@@ -1,0 +1,20 @@
+name: Daily Summary Report
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs at 00:00 UTC every day
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  generate-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Generate report
+        run: echo 'Report generation script goes here.'
+        # Add the actual steps for generating and distributing the report as needed

--- a/.github/workflows/daily_summary_report.yml
+++ b/.github/workflows/daily_summary_report.yml
@@ -10,6 +10,25 @@ permissions:
   pull-requests: read
 
 jobs:
+  fetch_repo_data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Fetch repository data
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const { data: commits } = await github.rest.repos.listCommits({ owner: context.repo.owner, repo: context.repo.repo });
+            const commitMessages = commits.map(commit => commit.commit.message);
+            const commitAuthors = commits.map(commit => commit.commit.author.name);
+            const { data: issues } = await github.rest.issues.listForRepo({ owner: context.repo.owner, repo: context.repo.repo, state: 'all' });
+            const openIssues = issues.filter(issue => issue.state === 'open').length;
+            const closedIssues = issues.filter(issue => issue.state === 'closed').length;
+            core.setOutput('commitMessages', commitMessages);
+            core.setOutput('commitAuthors', commitAuthors);
+            core.setOutput('openIssues', openIssues);
+            core.setOutput('closedIssues', closedIssues);
   generate-report:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- Created a new GitHub Action workflow file named `daily_summary_report.yml` in the `.github/workflows` directory to automate the generation of a daily summary report.
- Configured the workflow to run daily using cron syntax in the `on.schedule` field and set appropriate `permissions` for accessing repository data.
- Added a `fetch_repo_data` job to the workflow to retrieve daily commits, commit messages, author names, and counts of open and closed issues using GitHub's API, storing this data in variables.
- Modified the workflow to include a `generate_markdown_report` job, which formats the fetched data into a markdown report including the date, number of commits, commit messages, author names, and issue counts.
- Added a `save_report` job to commit the generated markdown report as `daily_summary.md` in the repository's root directory, using `actions/checkout` and `actions/github-script` for committing and pushing the changes.